### PR TITLE
Updates

### DIFF
--- a/main/connectors.py
+++ b/main/connectors.py
@@ -1,11 +1,12 @@
 import os
 
 import psycopg2
-from rediscluster import RedisCluster
+from redis.cluster import RedisCluster
+from redis.cluster import ClusterNode
 
 def connectToCache(host, port, mapping, key,action,insertType):
     ROOTDIR = os.path.realpath(os.path.join(os.path.dirname(__file__), "..","resources"))
-    startup_nodes = [{"host": host, "port": port}]
+    startup_nodes = [ClusterNode(host, port)]
     rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True, skip_full_coverage_check=True)
     getValue = ""
     if "insert" in action:

--- a/main/dataload.py
+++ b/main/dataload.py
@@ -7,7 +7,8 @@ import json
 from pyformance import MetricsRegistry
 # from wavefront_pyformance.wavefront_reporter import WavefrontDirectReporter
 from psycopg2.extras import RealDictCursor
-from rediscluster import RedisCluster
+from redis.cluster import RedisCluster
+from redis.cluster import ClusterNode
 # from dotenv import load_dotenv
 FORMAT = '%(asctime)-15s %(message)s'
 logging.basicConfig(format=FORMAT)
@@ -31,7 +32,7 @@ def reload_campaigns():
 def process_reload():
     try:
         logger.info("Start up redis connection")
-        startup_nodes = [{"host": os.environ['REDIS_HOST'], "port": os.environ['REDIS_PORT']}]
+        startup_nodes = [ClusterNode(host=os.environ['REDIS_HOST'], port=os.environ['REDIS_PORT'])]
         rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True, skip_full_coverage_check=True)
 
         connection = psycopg2.connect(user=os.environ['POSTGRES_USER'],

--- a/main/requestsValidations.py
+++ b/main/requestsValidations.py
@@ -35,7 +35,7 @@ class runnerRunner():
         url = os.environ["MAGNITE_URL"]
         headers = {'Content-type': 'application/json'}
         tests = open(self.fixPath)
-        resultsFileName = "test_Results_{}".format(datetime.datetime.now())
+        resultsFileName = "test_Results_{}".format(datetime.datetime.now()).replace(':','.')
         testResults = os.path.join(self.ROOTDIR, "fixtures/testResults/{}".format(resultsFileName))
         file = open(testResults, "w+")
         for test in tests:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyformance==0.4
 pyparsing==3.0.9
 python-dotenv==0.21.0
 pytz==2022.6
-rediscluster==0.2.1
+redis==4.4.2
 requests==2.27.1


### PR DESCRIPTION
Use redis in stead of rediscluster module and replace invalid characters in the test output file names to work cross-OS.